### PR TITLE
Improve ArgoCD auth via kube token

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PyArgoCD
 
-PyArgoCD is a minimal Python wrapper around the ArgoCD API. It authenticates using your Kubernetes configuration so no `argocd` CLI is required. Provide the server URL and namespace and the client can list, refresh and sync your applications.
+PyArgoCD is a minimal Python wrapper around the ArgoCD API. It authenticates using your Kubernetes configuration so no `argocd` CLI is required. The client exchanges the bearer token from your current context for an ArgoCD session token and falls back to the initial admin password if that fails. Provide the server URL and namespace and the client can list, refresh and sync your applications.
 
 ```python
 from pyargocd.client import ArgoCDClient

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,16 +1,19 @@
 from unittest import mock
 
 import pytest
+import requests
 
 from pyargocd.client import ArgoCDClient
 
 
 def make_client():
     with mock.patch("kubernetes.config.load_kube_config"), \
-            mock.patch("kubernetes.client.CoreV1Api") as core:
+            mock.patch("kubernetes.client.CoreV1Api") as core, \
+            mock.patch("kubernetes.client.ApiClient") as api_client:
         core.return_value.read_namespaced_secret.return_value.data = {
             "password": "cGFzc3dvcmQ="  # base64 for "password"
         }
+        api_client.return_value.configuration.api_key = {"authorization": "Bearer k8s"}
         with mock.patch("requests.Session.post") as post:
             post.return_value.json.return_value = {"token": "dummy"}
             post.return_value.raise_for_status.return_value = None
@@ -50,5 +53,35 @@ def test_login_with_credentials():
             post.assert_called_with(
                 "https://example.com/api/v1/session",
                 json={"username": "foo", "password": "bar"},
+                timeout=10,
+            )
+
+
+def test_fallback_to_admin_password():
+    with mock.patch("kubernetes.config.load_kube_config"), \
+            mock.patch("kubernetes.client.CoreV1Api") as core, \
+            mock.patch("kubernetes.client.ApiClient") as api_client:
+        core.return_value.read_namespaced_secret.return_value.data = {
+            "password": "cGFzc3dvcmQ="
+        }
+        api_client.return_value.configuration.api_key = {"authorization": "Bearer k8s"}
+
+        call_responses = []
+
+        def side_effect(*args, **kwargs):
+            if not call_responses:
+                call_responses.append('first')
+                raise requests.exceptions.RequestException
+            mock_resp = mock.Mock()
+            mock_resp.json.return_value = {"token": "dummy"}
+            mock_resp.raise_for_status.return_value = None
+            return mock_resp
+
+        with mock.patch("requests.Session.post", side_effect=side_effect) as post:
+            ArgoCDClient(host="https://example.com", namespace="argocd")
+            assert post.call_count == 2
+            post.assert_called_with(
+                "https://example.com/api/v1/session",
+                json={"username": "admin", "password": "password"},
                 timeout=10,
             )


### PR DESCRIPTION
## Summary
- authenticate by exchanging the Kubernetes context token for an ArgoCD session
- fall back to the admin secret on failure
- document authentication behaviour in README
- expand unit tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_683c4b37bdc0832592ee8add97238dc6