### PR TITLE
Handle auth failures more gracefully

### DIFF
--- a/pyargocd/__init__.py
+++ b/pyargocd/__init__.py
@@ -1,5 +1,5 @@
 """PyArgoCD package."""
 
-from .client import ArgoCDClient
+from .client import ArgoCDClient, ArgoCDAuthError
 
-__all__ = ["ArgoCDClient"]
+__all__ = ["ArgoCDClient", "ArgoCDAuthError"]


### PR DESCRIPTION
## Summary
- define `ArgoCDAuthError`
- wrap login and secret reads to raise `ArgoCDAuthError`
- export new exception
- test missing secrets or failed login raise the error

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_683c4d91aad88325b6d6f1f4f2d32127